### PR TITLE
Fix a null instance error with the cross fade tween

### DIFF
--- a/src/init.lua
+++ b/src/init.lua
@@ -307,6 +307,10 @@ end
 function MusicController:Stop()
     -- Utl
     local function beginFade(sound: Sound)
+        if not sound then
+            return
+        end
+
         -- Setup Tween
         self._crossFadeStatus.FadeOutTween = TweenService:Create(
             sound,

--- a/wally.toml
+++ b/wally.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lfg-studio/musiccontroller"
-version = "0.1.1"
+version = "0.1.2"
 registry = "https://github.com/UpliftGames/wally-index"
 realm = "shared"
 


### PR DESCRIPTION
If I call `MusicController:PopulateLibrary()` then call `MusicController:Play()` without any yields, it will kick a null instance error. This attempts to fix that by just checking the reference to make sure it exists, but that could mean the controller isn't managing the sound anymore. Will need to ensure the sound is fading out/stopping as expected. 


![image](https://github.com/user-attachments/assets/de2ecb2a-42bf-4207-8f34-41066a503bf9)
